### PR TITLE
Fix bug of tags eating whitespace in tail

### DIFF
--- a/pypub/const.py
+++ b/pypub/const.py
@@ -140,18 +140,18 @@ def xmlprettify(elem: lxml.html.HtmlElement, chars: str='  ', _level: int=1):
     if children:
         # make modifications
         if elem.text:
-            elem.text = elem.text.strip() + start
+            elem.text = elem.text.rstrip() + start
         if elem.tail:
-            elem.tail = elem.tail.strip() + end
+            elem.tail = elem.tail.rstrip() + end
         # iterate children
         for child in children:
             xmlprettify(child, chars, _level + 1)
         # ensure last child has tail indentation of parent
-        child.tail = (child.tail or '').strip() + end
+        child.tail = (child.tail or '').rstrip() + end
     else:
-        elem.text = '' if not elem.text else elem.text.strip()
+        elem.text = '' if not elem.text else elem.text
         if elem.tail:
-            elem.tail = (elem.tail or '').strip() + end
+            elem.tail = (elem.tail or '').rstrip() + end
 
 #** Init **#
 log = _make_logger()


### PR DESCRIPTION
Hey, thank you for your python3 port! I generated an epub with this and noticed that some whitespace vanished somewhere along the line. I could trace my issue back to the `pypub.const.xmlprettify` method. There I noticed the following behavoir:
```python
test = lxml.html.fromstring("Test <em>Test</em> Test")
xmlprettify(test)
print(lxml.html.tostring(test, method="xml").decode())
```
gives the output:
```
<p>Test
  <em>Test</em>Test
</p>
``` 
which reads in the final file as (plus italics)
> Test TestTest

However, in my opinion the output should be something like
```
<p>Test
  <em>Test</em> Test
</p>
```
whch reads as expected:
> Test _Test_ Test

To fix this I changed the function to only remove whitespace where new whitespace is added as well instead of both in the front and the back. To be honest: I have basically no familarity with lxml or html in general, so I hope this change doesn't break other stuff and I'm not as sure whether this change is correct for the `elem.text`, but the `elem.tail` change seems necessary to me.

Hope this is helpful. Cheers