### PR TITLE
Fix wrong encoding when rendering templates

### DIFF
--- a/pypub/builder.py
+++ b/pypub/builder.py
@@ -118,7 +118,7 @@ def render_template(name: str, into: str, kwargs: dict):
     dest     = os.path.join(into, os.path.basename(fname))
     template = jinja_env.get_template(name)
     content  = template.render(**kwargs)
-    with open(dest, 'w') as f:
+    with open(dest, 'w', encoding='utf-8') as f:
         f.write(content)
 
 #** Classes **#


### PR DESCRIPTION
When using special characters (éèë for example) for a chapter title, the book.ncx file won't be properly rendered. Forcing the encoding to utf-8 seems to solve the issue.
Example of broken titles:
```
  <navMap>
    <navPoint id="chapter_1" playOrder="1">
      <navLabel><text>En-t�te 1</text></navLabel>
      <content src="1.xhtml"/>
    </navPoint>
    <navPoint id="chapter_2" playOrder="2">
      <navLabel><text>Deuxi�me Titre</text></navLabel>
      <content src="2.xhtml"/>
    </navPoint>
    <navPoint id="chapter_3" playOrder="3">
      <navLabel><text>Troisi�me Titre</text></navLabel>
      <content src="3.xhtml"/>
    </navPoint>
    <navPoint id="chapter_4" playOrder="4">
      <navLabel><text>Chapter 5</text></navLabel>
      <content src="4.xhtml"/>
    </navPoint>
    <navPoint id="chapter_5" playOrder="5">
      <navLabel><text>The End ?</text></navLabel>
      <content src="5.xhtml"/>
    </navPoint>
  </navMap>
```
