### PR TITLE
fix: Ensure image URLs quoted before download

### DIFF
--- a/pypub/factory.py
+++ b/pypub/factory.py
@@ -108,6 +108,7 @@ def render_images(ctx: 'RenderCtx', chunk_size: int = 8192):
     for image in ctx.etree.xpath('.//img[@src]'):
         # cleanup link and resolve relative paths
         url = image.attrib['src'].rsplit('?', 1)[0]
+        fmt = (ctx.chapter.title, url)
         if '://' not in url:
             if not ctx.chapter.url:
                 ctx.logger.warning(
@@ -117,8 +118,6 @@ def render_images(ctx: 'RenderCtx', chunk_size: int = 8192):
         else:
             # make sure the url is properly encoded
             url = urllib.parse.quote(url, safe=":/")
-
-        fmt = (ctx.chapter.title, url)
         # skip if url has already been downloaded
         if url in downloads:
             image.attrib['src'] = downloads[url]

--- a/pypub/factory.py
+++ b/pypub/factory.py
@@ -108,14 +108,17 @@ def render_images(ctx: 'RenderCtx', chunk_size: int = 8192):
     for image in ctx.etree.xpath('.//img[@src]'):
         # cleanup link and resolve relative paths
         url = image.attrib['src'].rsplit('?', 1)[0]
-        fmt = (ctx.chapter.title, url)
         if '://' not in url:
             if not ctx.chapter.url:
                 ctx.logger.warning(
                     'chapter[%s] cannot render image %r w/o chapter-url' % fmt)
                 continue
-            url = urllib.parse.urljoin(ctx.chapter.url, url)
-            fmt = (ctx.chapter.title, url)
+            url = urllib.parse.urljoin(ctx.chapter.url, urllib.parse.quote(url))
+        else:
+            # make sure the url is properly encoded
+            url = urllib.parse.quote(url, safe=":/")
+
+        fmt = (ctx.chapter.title, url)
         # skip if url has already been downloaded
         if url in downloads:
             image.attrib['src'] = downloads[url]


### PR DESCRIPTION
When trying to use pypub to generate an ebook, the rendering process failed when it tried to download the image locate at https://teatimechinese.com/wp-content/uploads/2022/05/黄巾.jpg.

That happens because the Chinese characters need to be URL encoded prior to the request being made.

This change makes sure that image URLs get properly encoded before sending the GET request to download them.